### PR TITLE
Remove extra import.

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -1,5 +1,4 @@
 import tkinter as tk
-from tkinter.ttk import *
 import base64
 import pyperclip
 

--- a/GUIenc.py
+++ b/GUIenc.py
@@ -1,5 +1,4 @@
 import tkinter as tk
-from tkinter.ttk import *
 import base64
 import pyperclip
 


### PR DESCRIPTION
`from tkinter.ttk import *` is now useless due to the removal of that loading bar and separator. Either remove it or make something use it again.